### PR TITLE
fix windows 9.9.12

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,10 @@ function update(window) {
             window.setBackgroundMaterial(config.win32.material);
         }
         window.setBackgroundColor(config.win32.color);
+
+        if (config.win32.powerfulMode) {
+            window.once("focus", () => update(window));
+        }
     }
     if (LiteLoader.os.platform == "linux") {
         try {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -48,6 +48,13 @@ export const onSettingWindowCreated = async view => {
         config.win32.thickFrame = event.target.hasAttribute("is-active");
     }));
 
+    const win32_powerfulMode = view.querySelectorAll(".windows setting-switch")[3];
+    win32_powerfulMode.toggleAttribute("is-active", config.win32.powerfulMode);
+    win32_powerfulMode.addEventListener("click", update((event, config) => {
+        event.target.toggleAttribute("is-active");
+        config.win32.powerfulMode = event.target.hasAttribute("is-active");
+    }));
+
     const linux_material = view.querySelectorAll(".linux setting-select")[0];
     linux_material.querySelector(`[data-value="${config.linux.material}"]`).click()
     linux_material.addEventListener("selected", update((event, config) => {

--- a/static/config.json
+++ b/static/config.json
@@ -4,7 +4,8 @@
         "color": "rgba(127, 127, 127, 0.15)",
         "transparent": false,
         "frame": false,
-        "thickFrame": true
+        "thickFrame": true,
+        "powerfulMode": false
     },
     "linux": {
         "material": "blur",

--- a/static/settings.html
+++ b/static/settings.html
@@ -93,6 +93,14 @@
                 </div>
                 <setting-switch></setting-switch>
             </setting-item>
+            <setting-item>
+                <div>
+                    <setting-text>Powerful Mode</setting-text>
+                    <setting-text data-type="secondary" title="所以为什么是输入框……">强力模式，防止点击托盘图标或者窗口重载后焦点输入框引发的窗体设置失效。</setting-text>
+                    <setting-text data-type="secondary"><small>适用于9.9.12-25765，QQ启动后切换一下窗口生效。</small></setting-text>
+                </div>
+                <setting-switch></setting-switch>
+            </setting-item>
         </setting-list>
     </setting-panel>
     <setting-panel class="linux">


### PR DESCRIPTION
点击托盘图标会导致透明失效，初诊结果是focus输入框导致的，真是神神又秘秘。
加入一个简单的强力模式，每次focus的时候重新设置。