### PR TITLE
fix(renderer): use `import...with` instead of `import...assert`

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,5 +1,5 @@
-import manifest from "../manifest.json" assert {type: "json"};
-import default_config from "../static/config.json" assert {type: "json"};
+import manifest from "../manifest.json" with {type: "json"};
+import default_config from "../static/config.json" with {type: "json"};
 
 
 export const onSettingWindowCreated = async view => {


### PR DESCRIPTION
此提交可修复在更新版本的qq中`assert`报错问题
原因是chromium已弃用`assert`关键字